### PR TITLE
Commented clear_session_defaults

### DIFF
--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -87,7 +87,7 @@ on_session_creation = [
 	"frappe.core.doctype.user.user.notify_admin_access_to_system_manager"
 ]
 
-on_logout = "frappe.core.doctype.session_default_settings.session_default_settings.clear_session_defaults"
+# on_logout = "frappe.core.doctype.session_default_settings.session_default_settings.clear_session_defaults"
 
 # permissions
 


### PR DESCRIPTION
Comente el hook on_logout que llamaba a `clear_session_defaults` para que no se limpie al deslogearse.
