### PR TITLE
Mercadolibre integration

### DIFF
--- a/frappe/core/doctype/sms_settings/sms_settings.json
+++ b/frappe/core/doctype/sms_settings/sms_settings.json
@@ -60,7 +60,7 @@
  "idx": 1,
  "issingle": 1,
  "links": [],
- "modified": "2021-05-12 20:01:46.722016",
+ "modified": "2021-10-14 14:03:41.035975",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "SMS Settings",
@@ -74,7 +74,7 @@
    "write": 1
   }
  ],
- "restrict_to_domain": "Campaigns",
+ "restrict_to_domain": "Thrash",
  "sort_field": "modified",
  "sort_order": "DESC",
  "track_changes": 1

--- a/frappe/integrations/doctype/braintree_settings/braintree_settings.json
+++ b/frappe/integrations/doctype/braintree_settings/braintree_settings.json
@@ -234,7 +234,7 @@
  "issingle": 0, 
  "istable": 0, 
  "max_attachments": 0, 
- "modified": "2018-02-05 14:33:06.050377", 
+ "modified": "2021-10-14 12:56:02.903982", 
  "modified_by": "Administrator", 
  "module": "Integrations", 
  "name": "Braintree Settings", 
@@ -263,6 +263,7 @@
   }
  ], 
  "quick_entry": 1, 
+ "restrict_to_domain": "Thrash", 
  "read_only": 0, 
  "read_only_onload": 0, 
  "show_name_in_global_search": 0, 

--- a/frappe/integrations/doctype/dropbox_settings/dropbox_settings.json
+++ b/frappe/integrations/doctype/dropbox_settings/dropbox_settings.json
@@ -107,7 +107,7 @@
  "in_create": 1,
  "issingle": 1,
  "links": [],
- "modified": "2021-05-12 19:59:46.041222",
+ "modified": "2021-10-14 12:39:58.154979",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Dropbox Settings",
@@ -126,7 +126,7 @@
   }
  ],
  "read_only": 1,
- "restrict_to_domain": "Integrations",
+ "restrict_to_domain": "Thrash",
  "sort_field": "modified",
  "sort_order": "DESC",
  "track_changes": 1

--- a/frappe/integrations/doctype/google_calendar/google_calendar.json
+++ b/frappe/integrations/doctype/google_calendar/google_calendar.json
@@ -110,7 +110,7 @@
   }
  ],
  "links": [],
- "modified": "2021-05-12 20:01:51.497514",
+ "modified": "2021-10-14 12:50:52.063352",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Google Calendar",
@@ -142,7 +142,7 @@
    "write": 1
   }
  ],
- "restrict_to_domain": "Servicios Google",
+ "restrict_to_domain": "Thrash",
  "sort_field": "modified",
  "sort_order": "DESC",
  "track_changes": 1

--- a/frappe/integrations/doctype/google_contacts/google_contacts.json
+++ b/frappe/integrations/doctype/google_contacts/google_contacts.json
@@ -99,7 +99,7 @@
   }
  ],
  "links": [],
- "modified": "2021-05-12 20:01:51.253996",
+ "modified": "2021-10-14 12:50:14.606585",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Google Contacts",
@@ -128,7 +128,7 @@
    "write": 1
   }
  ],
- "restrict_to_domain": "Servicios Google",
+ "restrict_to_domain": "Thrash",
  "sort_field": "modified",
  "sort_order": "ASC",
  "track_changes": 1

--- a/frappe/integrations/doctype/google_drive/google_drive.json
+++ b/frappe/integrations/doctype/google_drive/google_drive.json
@@ -102,7 +102,7 @@
  ],
  "issingle": 1,
  "links": [],
- "modified": "2021-05-12 20:01:51.774382",
+ "modified": "2021-10-14 12:48:11.245182",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Google Drive",
@@ -129,7 +129,7 @@
    "write": 1
   }
  ],
- "restrict_to_domain": "Servicios Google",
+ "restrict_to_domain": "Thrash",
  "sort_field": "modified",
  "sort_order": "ASC",
  "track_changes": 1

--- a/frappe/integrations/doctype/google_settings/google_settings.json
+++ b/frappe/integrations/doctype/google_settings/google_settings.json
@@ -51,7 +51,7 @@
  ],
  "issingle": 1,
  "links": [],
- "modified": "2021-05-12 20:01:51.048012",
+ "modified": "2021-10-14 12:49:48.508736",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Google Settings",
@@ -79,7 +79,7 @@
   }
  ],
  "quick_entry": 1,
- "restrict_to_domain": "Servicios Google",
+ "restrict_to_domain": "Thrash",
  "sort_field": "modified",
  "sort_order": "ASC",
  "track_changes": 1

--- a/frappe/integrations/doctype/ldap_settings/ldap_settings.json
+++ b/frappe/integrations/doctype/ldap_settings/ldap_settings.json
@@ -266,7 +266,7 @@
  "in_create": 1,
  "issingle": 1,
  "links": [],
- "modified": "2021-07-27 11:51:43.328271",
+ "modified": "2021-10-14 12:52:03.544207",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "LDAP Settings",
@@ -285,7 +285,7 @@
   }
  ],
  "read_only": 1,
- "restrict_to_domain": "Integrations",
+ "restrict_to_domain": "Thrash",
  "sort_field": "modified",
  "sort_order": "DESC",
  "track_changes": 1

--- a/frappe/integrations/doctype/oauth_client/oauth_client.json
+++ b/frappe/integrations/doctype/oauth_client/oauth_client.json
@@ -117,7 +117,7 @@
   }
  ],
  "links": [],
- "modified": "2021-05-12 19:59:45.550141",
+ "modified": "2021-10-14 12:52:48.639266",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "OAuth Client",
@@ -136,7 +136,7 @@
    "write": 1
   }
  ],
- "restrict_to_domain": "Integrations",
+ "restrict_to_domain": "Thrash",
  "sort_field": "modified",
  "sort_order": "DESC",
  "title_field": "app_name",

--- a/frappe/integrations/doctype/oauth_provider_settings/oauth_provider_settings.json
+++ b/frappe/integrations/doctype/oauth_provider_settings/oauth_provider_settings.json
@@ -18,7 +18,7 @@
  ],
  "issingle": 1,
  "links": [],
- "modified": "2021-05-12 19:59:48.711927",
+ "modified": "2021-10-14 12:53:19.476507",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "OAuth Provider Settings",
@@ -36,7 +36,7 @@
   }
  ],
  "quick_entry": 1,
- "restrict_to_domain": "Integrations",
+ "restrict_to_domain": "Thrash",
  "sort_field": "modified",
  "sort_order": "DESC",
  "track_changes": 1

--- a/frappe/integrations/doctype/paypal_settings/paypal_settings.json
+++ b/frappe/integrations/doctype/paypal_settings/paypal_settings.json
@@ -51,7 +51,7 @@
  "in_create": 1,
  "issingle": 1,
  "links": [],
- "modified": "2021-05-12 19:59:48.510174",
+ "modified": "2021-10-14 12:56:41.672815",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "PayPal Settings",
@@ -70,7 +70,7 @@
   }
  ],
  "read_only": 1,
- "restrict_to_domain": "Integrations",
+ "restrict_to_domain": "Thrash",
  "sort_field": "modified",
  "sort_order": "DESC",
  "track_changes": 1

--- a/frappe/integrations/doctype/paytm_settings/paytm_settings.json
+++ b/frappe/integrations/doctype/paytm_settings/paytm_settings.json
@@ -54,7 +54,7 @@
  ],
  "issingle": 1,
  "links": [],
- "modified": "2021-05-12 19:59:44.431221",
+ "modified": "2021-10-14 12:58:11.242881",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Paytm Settings",
@@ -71,7 +71,7 @@
    "write": 1
   }
  ],
- "restrict_to_domain": "Integrations",
+ "restrict_to_domain": "Thrash",
  "sort_field": "modified",
  "sort_order": "DESC",
  "track_changes": 1

--- a/frappe/integrations/doctype/razorpay_settings/razorpay_settings.json
+++ b/frappe/integrations/doctype/razorpay_settings/razorpay_settings.json
@@ -35,7 +35,7 @@
  "in_create": 1,
  "issingle": 1,
  "links": [],
- "modified": "2021-05-12 19:59:48.305614",
+ "modified": "2021-10-14 12:57:11.879289",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Razorpay Settings",
@@ -54,7 +54,7 @@
   }
  ],
  "read_only": 1,
- "restrict_to_domain": "Integrations",
+ "restrict_to_domain": "Thrash",
  "sort_field": "modified",
  "sort_order": "DESC",
  "track_changes": 1

--- a/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.json
+++ b/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.json
@@ -129,7 +129,7 @@
  "hide_toolbar": 1,
  "issingle": 1,
  "links": [],
- "modified": "2021-05-12 19:59:42.924964",
+ "modified": "2021-10-14 12:40:44.737906",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "S3 Backup Settings",
@@ -147,7 +147,7 @@
   }
  ],
  "quick_entry": 1,
- "restrict_to_domain": "Integrations",
+ "restrict_to_domain": "Thrash",
  "sort_field": "modified",
  "sort_order": "DESC",
  "track_changes": 1

--- a/frappe/integrations/doctype/slack_webhook_url/slack_webhook_url.json
+++ b/frappe/integrations/doctype/slack_webhook_url/slack_webhook_url.json
@@ -35,7 +35,7 @@
   }
  ],
  "links": [],
- "modified": "2021-05-12 18:24:37.810235",
+ "modified": "2021-10-14 12:59:06.304078",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Slack Webhook URL",
@@ -55,7 +55,7 @@
   }
  ],
  "quick_entry": 1,
- "restrict_to_domain": "Integrations",
+ "restrict_to_domain": "Thrash",
  "sort_field": "modified",
  "sort_order": "DESC",
  "track_changes": 1

--- a/frappe/integrations/doctype/social_login_key/social_login_key.json
+++ b/frappe/integrations/doctype/social_login_key/social_login_key.json
@@ -161,7 +161,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2021-05-12 19:59:43.476863",
+ "modified": "2021-10-14 12:51:28.696782",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Social Login Key",
@@ -180,7 +180,7 @@
    "write": 1
   }
  ],
- "restrict_to_domain": "Integrations",
+ "restrict_to_domain": "Thrash",
  "sort_field": "modified",
  "sort_order": "DESC",
  "title_field": "provider_name",

--- a/frappe/integrations/doctype/stripe_settings/stripe_settings.json
+++ b/frappe/integrations/doctype/stripe_settings/stripe_settings.json
@@ -62,7 +62,7 @@
   }
  ],
  "links": [],
- "modified": "2021-05-12 19:59:47.049506",
+ "modified": "2021-10-14 12:57:45.618629",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Stripe Settings",
@@ -80,7 +80,7 @@
   }
  ],
  "quick_entry": 1,
- "restrict_to_domain": "Integrations",
+ "restrict_to_domain": "Thrash",
  "sort_field": "modified",
  "sort_order": "DESC"
 }

--- a/frappe/integrations/doctype/webhook/webhook.json
+++ b/frappe/integrations/doctype/webhook/webhook.json
@@ -166,7 +166,7 @@
   }
  ],
  "links": [],
- "modified": "2021-05-25 11:11:28.555291",
+ "modified": "2021-10-14 12:58:38.425911",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Webhook",
@@ -185,7 +185,7 @@
    "write": 1
   }
  ],
- "restrict_to_domain": "Integrations",
+ "restrict_to_domain": "Thrash",
  "sort_field": "modified",
  "sort_order": "DESC",
  "title_field": "webhook_doctype",


### PR DESCRIPTION
## Relacionados

https://github.com/fproldan/ecommerce_integrations/issues/5

## Comentarios

Se agregan los roles requeridos para la integración de Mercadolibre de la app `ecommerce_integracion`.

Se agregó la restricción al dominio `Thrash` para los siguientes DocTypes:
- SMS Settings
- Braintree Settings
- Dropbox Settings
- Google Calendar
- Google Contacts
- Google Drive
- Google Settings
- LDAP Settings
- OAuth Client
- OAuth Provider Settings
- PayPal Settings
- Paytm Setting
- Razorpay Settings
- S3 Backup Settings
- Slack Webhook URL
- Social Login Key
- Stripe Settings
- Webhook

Todos estos DocTypes estaban relacionados al Workspace `Integrations`. Con este nuevo dominio se los oculta, ya que sólo queremos mostrar los DocTypes de la integración de Mercadolibre.