### PR TITLE
Link Documentación

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/navbar.html
+++ b/frappe/public/js/frappe/ui/toolbar/navbar.html
@@ -73,7 +73,7 @@
 						{% for item in navbar_settings.help_dropdown %}
 							{% if (!item.hidden) { %}
 								{% if (item.route) { %}
-									<a class="dropdown-item" href="{{ item.route }}">
+									<a class="dropdown-item" href="{{ item.route }}" target="_blank">
 										{%= __(item.item_label) %}
 									</a>
 								{% } else if (item.action) { %}


### PR DESCRIPTION
Agregué para que el dropdown de ayuda abra en otra pestaña los items que son links externos, en este caso Documentación y Crear un Ticket.



https://github.com/fproldan/DiamoERP/issues/212