### PR TITLE
Error al ingresar a Registro de hora (#289) (#291)

### DIFF
--- a/cypress/integration/control_link.js
+++ b/cypress/integration/control_link.js
@@ -58,6 +58,23 @@ context('Control Link', () => {
 		cy.get('.frappe-control[data-fieldname=link] input').should('have.value', '');
 	});
 
+	it("should be possible set empty value explicitly", () => {
+		get_dialog_with_link().as("dialog");
+
+		cy.intercept("POST", "/api/method/frappe.client.validate_link").as("validate_link");
+
+		cy.get(".frappe-control[data-fieldname=link] input")
+			.type("  ", { delay: 100 })
+			.blur();
+		cy.wait("@validate_link");
+		cy.get(".frappe-control[data-fieldname=link] input").should("have.value", "");
+		cy.window()
+			.its("cur_dialog")
+			.then((dialog) => {
+				expect(dialog.get_value("link")).to.equal('');
+			});
+	});
+
 	it('should route to form on arrow click', () => {
 		get_dialog_with_link().as('dialog');
 
@@ -78,7 +95,7 @@ context('Control Link', () => {
 		});
 	});
 
-	it('should fetch valid value', () => {
+	it('should update dependant fields (via fetch_from)', () => {
 		cy.get('@todos').then(todos => {
 			cy.visit(`/app/todo/${todos[0]}`);
 			cy.intercept('POST', '/api/method/frappe.client.validate_link').as('validate_link');
@@ -89,6 +106,67 @@ context('Control Link', () => {
 			cy.get('.frappe-control[data-fieldname=assigned_by_full_name] .control-value').should(
 				'contain', 'Administrator'
 			);
+
+			cy.window()
+				.its("cur_frm.doc.assigned_by")
+				.should("eq", "Administrator");
+
+			// invalid input
+			cy.get('@input').clear().type('invalid input', {delay: 100}).blur();
+			cy.get('.frappe-control[data-fieldname=assigned_by_full_name] .control-value').should(
+				'contain', ''
+			);
+
+			cy.window()
+				.its("cur_frm.doc.assigned_by")
+				.should("eq", null);
+
+			// set valid value again
+			cy.get('@input').clear().type('Administrator', {delay: 100}).blur();
+			cy.wait('@validate_link');
+
+			cy.window()
+				.its("cur_frm.doc.assigned_by")
+				.should("eq", "Administrator");
+
+			// clear input
+			cy.get('@input').clear().blur();
+			cy.get('.frappe-control[data-fieldname=assigned_by_full_name] .control-value').should(
+				'contain', ''
+			);
+
+			cy.window()
+				.its("cur_frm.doc.assigned_by")
+				.should("eq", "");
 		});
+	});
+
+	it("should set default values", () => {
+		cy.insert_doc("Property Setter", {
+			"doctype_or_field": "DocField",
+			"doc_type": "ToDo",
+			"field_name": "assigned_by",
+			"property": "default",
+			"property_type": "Text",
+			"value": "Administrator"
+		}, true);
+		cy.reload();
+		cy.new_form("ToDo");
+		cy.fill_field("description", "new", "Text Editor");
+		cy.intercept("POST", "/api/method/frappe.desk.form.save.savedocs").as("save_form");
+		cy.findByRole("button", {name: "Save"}).click();
+		cy.wait("@save_form");
+		cy.get(".frappe-control[data-fieldname=assigned_by_full_name] .control-value").should(
+			"contain", "Administrator"
+		);
+		// if user clears default value explicitly, system should not reset default again
+		cy.get_field("assigned_by").clear().blur();
+		cy.intercept("POST", "/api/method/frappe.desk.form.save.savedocs").as("save_form");
+		cy.findByRole("button", {name: "Save"}).click();
+		cy.wait("@save_form");
+		cy.get_field("assigned_by").should("have.value", "");
+		cy.get(".frappe-control[data-fieldname=assigned_by_full_name] .control-value").should(
+			"contain", ""
+		);
 	});
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -110,34 +110,6 @@ Cypress.Commands.add('get_doc', (doctype, name) => {
 		});
 });
 
-Cypress.Commands.add('insert_doc', (doctype, args, ignore_duplicate) => {
-	return cy
-		.window()
-		.its('frappe.csrf_token')
-		.then(csrf_token => {
-			return cy
-				.request({
-					method: 'POST',
-					url: `/api/resource/${doctype}`,
-					body: args,
-					headers: {
-						Accept: 'application/json',
-						'Content-Type': 'application/json',
-						'X-Frappe-CSRF-Token': csrf_token
-					},
-					failOnStatusCode: !ignore_duplicate
-				})
-				.then(res => {
-					let status_codes = [200];
-					if (ignore_duplicate) {
-						status_codes.push(409);
-					}
-					expect(res.status).to.be.oneOf(status_codes);
-					return res.body;
-				});
-		});
-});
-
 Cypress.Commands.add('remove_doc', (doctype, name) => {
 	return cy
 		.window()

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -373,15 +373,28 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 		return __('Filters applied for {0}', [filter_string]);
 	},
 
-	set_custom_query: function(args) {
-		var set_nulls = function(obj) {
-			$.each(obj, function(key, value) {
-				if(value!==undefined) {
-					obj[key] = value;
+	set_custom_query(args) {
+		const is_valid_value = (value, key) => {
+			if (value) return true;
+			// check if empty value is valid
+			if (this.frm) {
+				let field = frappe.meta.get_docfield(this.frm.doctype, key);
+				// empty value link fields is invalid
+				return !field || !["Link", "Dynamic Link"].includes(field.fieldtype);
+			} else {
+				return value !== undefined;
+			}
+		};
+
+		const set_nulls = (obj) => {
+			$.each(obj, (key, value) => {
+				if (!is_valid_value(value, key)) {
+					delete obj[key];
 				}
 			});
 			return obj;
 		};
+
 		if(this.get_query || this.df.get_query) {
 			var get_query = this.get_query || this.df.get_query;
 			if($.isPlainObject(get_query)) {
@@ -408,13 +421,13 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 					// add "filters" for standard query (search.py)
 					args.filters = filters;
 				}
-			} else if(typeof(get_query)==="string") {
+			} else if (typeof (get_query) === "string") {
 				args.query = get_query;
 			} else {
 				// get_query by function
 				var q = (get_query)(this.frm && this.frm.doc || this.doc, this.doctype, this.docname);
 
-				if (typeof(q)==="string") {
+				if (typeof (q) ==="string") {
 					// returns a string
 					args.query = q;
 				} else if($.isPlainObject(q)) {
@@ -459,7 +472,6 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 	validate_link_and_fetch(df, options, docname, value) {
 		if (!options) return;
 
-		let field_value = "";
 		const fetch_map = this.get_fetch_map();
 		const columns_to_fetch = Object.values(fetch_map);
 
@@ -468,16 +480,10 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 			return value;
 		}
 
-		return frappe.xcall("frappe.client.validate_link", {
-			doctype: options,
-			docname: value,
-			fields: columns_to_fetch,
-		}).then((response) => {
-			if (!docname || !columns_to_fetch.length) return response.name;
-
+		function update_dependant_fields(response) {
+			let field_value = "";
 			for (const [target_field, source_field] of Object.entries(fetch_map)) {
-				if(value) field_value = response[source_field];
-
+				if (value) field_value = response[source_field];
 				frappe.model.set_value(
 					df.parent,
 					docname,
@@ -486,9 +492,23 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 					df.fieldtype,
 				);
 			}
+		}
 
-			return response.name;
-		});
+		// to avoid unnecessary request
+		if (value) {
+			return frappe.xcall("frappe.client.validate_link", {
+				doctype: options,
+				docname: value,
+				fields: columns_to_fetch,
+			}).then((response) => {
+				if (!docname || !columns_to_fetch.length) return response.name;
+				update_dependant_fields(response);
+				return response.name;
+			});
+		} else {
+			update_dependant_fields({});
+			return value;
+		}
 	},
 
 	get_fetch_map() {


### PR DESCRIPTION
* fix: Call validate_link only if "value" is passed

* test: Update UI test for link field

* test: Update test case for default value in link field

* fix: Update set_nulls code to filters out empty values for link fields

- Empty values for link field is invalid and causes issue mentioned here https://github.com/frappe/frappe/pull/15320

* chore: Remove duplicate command

* fix: Update filter whilte removing undefined

Co-authored-by: Suraj Shetty <surajshetty3416@gmail.com>

Co-authored-by: Francisco Roldán <franciscoproldan@gmail.com>
Co-authored-by: Suraj Shetty <surajshetty3416@gmail.com>

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
